### PR TITLE
[minor] Fill in link to sigstore YouTube channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Use [GitHub Issues](https://github.com/sigstore/tac/issues) to request and discu
 
 The TSC [meetings minutes](https://docs.google.com/document/d/1yr7kib0jgmPbIM0nuNUa28_ur-Ze_pfhgCW9f78oL0I).
 
-Meetings are also recorded and posted to the [sigstore YouTube channel](pending).
+Meetings are also recorded and posted to the [sigstore YouTube channel](https://www.youtube.com/channel/UCWPVc8glVGOODxsA_ep0VVw/featured).
 
 ## Members
 


### PR DESCRIPTION
#### Summary

Saw that the link was pending in README, while the channel existed. So I thought to update it.

It should match the channel from https://github.com/sigstore/community/blob/aaf063a1bb4484b0993119fb85b3801412ce6ec8/README.md

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
